### PR TITLE
Showing the difference between join and detach

### DIFF
--- a/000_join_vs_detach.cpp
+++ b/000_join_vs_detach.cpp
@@ -2,14 +2,22 @@
 #include <thread>
 #include <chrono>
 
+//Thread routine that takes more time to execute
 void fun(){
-    std::this_thread::sleep_for(std::chrono::milliseconds(2'000));
-    std::cout << "in fun" << std::endl;
+    for(int i=0; i<5; i++)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1'000));
+        std::cout << "in fun. count: " << i + 1 << std::endl;
+    }
 }
 
+//Thread routine that takes lesser time to execute
 void fun2(){
-    std::this_thread::sleep_for(std::chrono::milliseconds(2'000));
-    std::cout << "in fun2" << std::endl;
+    for(int i=0; i<5; i++)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        std::cout << "in fun2. count: " << i + 1 << std::endl;
+    }
 }
 
 int main(){
@@ -19,3 +27,14 @@ int main(){
     t2.join();
     return 0;
 }
+
+/*
+Output:
+in fun2. count: 1
+in fun. count: 1
+in fun2. count: 2
+in fun2. count: 3
+in fun. count: 2
+in fun2. count: 4
+in fun2. count: 5
+*/


### PR DESCRIPTION
I have added some changes to prominently show the differences between `std::thread::join` and `std::thread::detach`.

As we can see in the output the thread which is being joined executes fully where as the thread that is detached terminates prematurely as the execution ends.

This will help in the better understanding for your viewers and students. Hoping it could be of some help.
Here is a sample output:
![image](https://github.com/thenaserov/multithreading-in-cplusplus/assets/16662695/37e00a12-0f6a-43f7-b631-d31a57619314)

As we can see the `fun2` executes fully and `fun` executes only 2 times when it should also execute the same number of times.